### PR TITLE
change name in dependencies to puppetlabs/stdlib and puppetlabs/powershell

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -34,11 +34,11 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_requirement": "4.x"
     },
     {
-      "name": "puppetlabs-powershell",
+      "name": "puppetlabs/powershell",
       "version_requirement": "1.x"
     }
   ]


### PR DESCRIPTION
Got following error:

```
# puppet module list

Warning: Missing dependency 'puppetlabs-powershell':
  'puppetlabs-mount_iso' (v0.1.0) requires 'puppetlabs-powershell' (v1.x)
Warning: Missing dependency 'puppetlabs-stdlib':
  'puppetlabs-mount_iso' (v0.1.0) requires 'puppetlabs-stdlib' (v4.x)
```

i look at other projects for the dependency name and it's puppetlabs/powershell and puppetlabs/stdlib
