### PR TITLE
MODULES-6389 - mount_iso: metadata project incorrect

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "summary": "Mount ISO images and ensure the drive letter they are mounted to",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-mount_iso",
-  "project_page": "https://tickets.puppetlabs.com/browse/MODULES",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-mount_iso",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "tags": [
     "mount",
@@ -20,6 +20,7 @@
         "Server 2008 R2",
         "Server 2012",
         "Server 2012 R2",
+        "Server 2016",
         "8",
         "10"
       ]
@@ -28,15 +29,17 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ],
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib"
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
-      "name": "puppetlabs-powershell"
+      "name": "puppetlabs-powershell",
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ]
 }


### PR DESCRIPTION
This update points the `project` attribute at the correct location.