### PR TITLE
(maint) Update name in dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -34,11 +34,11 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
-      "name": "puppetlabs-powershell",
+      "name": "puppetlabs/powershell",
       "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ]


### PR DESCRIPTION
The dependency names use a hyphen instead of forwardslash.  This can cause
puppet to raise errors when running puppet module list.

This commit changes them to the normal forward slash.