### PR TITLE
(GH-3) Raise mounting errors as fatal 

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,10 @@
 fixtures:
-  repositories:
+  forge_modules:
     stdlib:
-      repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '4.3.0'
+      repo: "puppetlabs/stdlib"
+      ref: "4.24.0"
+    powershell:
+      repo: "puppetlabs/powershell"
+      ref: "2.1.3"
   symlinks:
     mount_iso: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,11 +21,12 @@
 #
 # Travis Fields
 #
-define mount_iso ($drive_letter, $source = $title){
+define mount_iso (
+  Pattern[/^[a-zA-Z]$/]  $drive_letter,
+  Optional[Stdlib::Absolutepath] $source = $title
+){
 
   if $::osfamily != 'windows' { fail('Unsupported OS') }
-  validate_re($drive_letter, '^[a-zA-Z]$', 'Drive letter must only be a single character')
-  validate_absolute_path($source)
 
   exec{ "Mount-Iso-${source}":
     provider => powershell,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,7 +30,7 @@ define mount_iso (
 
   exec{ "Mount-Iso-${source}":
     provider => powershell,
-    command  => "Mount-DiskImage -ImagePath '${source}'",
+    command  => "Mount-DiskImage -ImagePath '${source}' -ErrorAction 'Stop'",
     onlyif   => "if ( (Get-DiskImage -ImagePath '${source}').Attached ){ exit 1 } else { exit 0 }",
     before   => Exec["Change-Mount-Letter-${drive_letter}"],
   }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'mount_iso' do
   it 'should contain exec for mount' do
     should contain_exec("Mount-Iso-#{title}").with(
                {
-                   'command' => "Mount-DiskImage -ImagePath '#{title}'",
+                   'command' => "Mount-DiskImage -ImagePath '#{title}' -ErrorAction 'Stop'",
                    'onlyif' => "if ( (Get-DiskImage -ImagePath '#{title}').Attached ){ exit 1 } else { exit 0 }",
                }
            )


### PR DESCRIPTION
Previously the module used the now deprecated stdlib functions.  This commit
modifies the mount_iso defined type to use the equivalent Puppet 4 parameter
types.

Previously the Mount powershell command would not surface errors encountered
in PowerShell through to Puppet. This commit changes the ErrorAction to be
'Stop' which will force any errors that are encountered to stop the puppet run.