### PR TITLE
(MAINT) - Remove powershell dependency upper bound

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">= 2.0.0 < 4.0.0"
+      "version_requirement": ">= 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Prior to this PR, the mount_iso module had an explicit dependency on versions 4 and below of the puppetlabs-powershell module. 

This caused a dependency conflict when using the puppetlabs-sqlserver module as it depends on both the powershell and mount_iso modules, so installed a higher version of puppetlabs-powershell then was allowed by the mount_iso module causing errors.